### PR TITLE
Added update language by ID API to the service

### DIFF
--- a/src/controllers/support-language-controllers/getLanguage.controller.js
+++ b/src/controllers/support-language-controllers/getLanguage.controller.js
@@ -27,6 +27,7 @@ const getLangById = async (langId, deletedRecord = false) => {
     langDtl = langDtl.rows[0];
     langDtl = {
       id: convertIdToPrettyString(langDtl.id),
+      typeId: convertIdToPrettyString(langDtl.type_id),
       langCode: langDtl.lang_cd,
       language: langDtl.language,
       typeDesc: langDtl.type_desc,

--- a/src/controllers/support-language-controllers/index.js
+++ b/src/controllers/support-language-controllers/index.js
@@ -2,10 +2,12 @@
 
 import { verifyLanguageExist, registerNewLanguageType } from './registerLanguage.controller.js';
 import { getLangById, getAllLanguageInfo } from './getLanguage.controller.js';
+import { updateLanguageInfoById } from './updateLanguage.controller.js';
 
 export default {
   verifyLanguageExist,
   registerNewLanguageType,
   getLangById,
   getAllLanguageInfo,
+  updateLanguageInfoById,
 };

--- a/src/controllers/support-language-controllers/updateLanguage.controller.js
+++ b/src/controllers/support-language-controllers/updateLanguage.controller.js
@@ -1,0 +1,45 @@
+'use strict';
+
+import { convertPrettyStringToId, logger } from 'common-node-lib';
+import { updateLanguageInfo } from '../../db/index.js';
+import { getLangById } from './getLanguage.controller.js';
+
+const log = logger('Controller: update-support-language');
+
+const updateLanguageInfoById = async (langId, userId, langDtl, payload) => {
+  try {
+    log.info('Controller function to update the language info process initiated');
+    payload.typeId = payload.typeId || langDtl.typeId;
+    payload.language = payload.language || langDtl.language;
+    langId = convertPrettyStringToId(langId);
+    userId = convertPrettyStringToId(userId);
+    payload.typeId = convertPrettyStringToId(payload.typeId);
+
+    log.info('Call db query to update the language info in system');
+    await updateLanguageInfo(langId, userId, payload);
+    const updatedLangDtl = await getLangById(langId);
+    if (!updatedLangDtl.isValid) {
+      throw updatedLangDtl;
+    }
+
+    log.success('Language details updated successfully');
+    return {
+      status: 200,
+      message: 'Language details updated successfully',
+      data: updatedLangDtl.data,
+      isValid: true,
+    };
+  } catch (err) {
+    log.error('Error while updating language info for requested id in system');
+    return {
+      status: 500,
+      message: 'An error occurred while updating language info',
+      data: [],
+      errors: err,
+      stack: err.stack,
+      isValid: false,
+    };
+  }
+};
+
+export { updateLanguageInfoById };

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -17,6 +17,7 @@ import {
   registerNewLanguage,
   getLangInfoById,
   getAllLanguages,
+  updateLanguageInfo,
 } from './problem.db.js';
 
 export {
@@ -36,4 +37,5 @@ export {
   registerNewLanguage,
   getLangInfoById,
   getAllLanguages,
+  updateLanguageInfo,
 };

--- a/src/db/problem.db.js
+++ b/src/db/problem.db.js
@@ -109,7 +109,7 @@ const registerNewLanguage = async (typeId, langCode, language) => {
 };
 
 const getLangInfoById = async (langId, deletedRecord) => {
-  const query = `SELECT S.ID, S.LANG_CD, S.LANGUAGE, P.TYPE_DESC, S.CREATED_DATE, S.MODIFIED_DATE
+  const query = `SELECT S.ID, S.TYPE_ID, S.LANG_CD, S.LANGUAGE, P.TYPE_DESC, S.CREATED_DATE, S.MODIFIED_DATE
     FROM SUPPORT_LANGUAGE S
     INNER JOIN PROBLEM_TYPE P ON P.ID = S.TYPE_ID
     WHERE S.ID = ? AND S.IS_DELETED = ?;`;
@@ -121,6 +121,14 @@ const getLangInfoById = async (langId, deletedRecord) => {
 const getAllLanguages = async () => {
   const query = `SELECT ID, LANG_CD, LANGUAGE FROM SUPPORT_LANGUAGE WHERE IS_DELETED = false;`;
   return exec(query);
+};
+
+const updateLanguageInfo = async (langId, userId, payload) => {
+  const query = `UPDATE SUPPORT_LANGUAGE SET TYPE_ID = ?, LANGUAGE = ?, MODIFIED_BY = ?
+    WHERE ID = ?`;
+  const params = [payload.typeId, payload.language, userId, langId];
+
+  return exec(query, params);
 };
 
 export {
@@ -140,4 +148,5 @@ export {
   registerNewLanguage,
   getLangInfoById,
   getAllLanguages,
+  updateLanguageInfo,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ class ProblemService extends Service {
     this.app.post(`${PROBLEMS_API}/language`, routes.language.registerSupportLanguage);
     this.app.get(`${PROBLEMS_API}/language`, routes.language.getLanguageInfo);
     this.app.get(`${PROBLEMS_API}/language/:langId`, routes.language.getLanguageInfo);
+    this.app.put(`${PROBLEMS_API}/language/:langId`, routes.language.updateLanguageInfo);
 
     // Problem Routes
     // this.app.post(`${PROBLEMS_API}/problem`, );

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -121,6 +121,20 @@ components:
         - langCode
         - language
 
+    updateLanguagePayload:
+      type: object
+      properties:
+        typeId:
+          type: string
+          description: Type ID
+          minLength: 30
+        language:
+          type: string
+          description: Language Detail
+          minLength: 1
+        metadata:
+          type: string
+
     healthCheckData:
       title: Schema for Health Check Data
       type: object
@@ -188,6 +202,8 @@ components:
       type: object
       properties:
         id:
+          type: string
+        typeId:
           type: string
         langCode:
           type: string
@@ -1252,6 +1268,62 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/notFound'
+        '500':
+          description: INTERNAL_SERVER_ERROR
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/internalServerErrorResponse'
+
+    put:
+      operationId: updateLanguageById
+      summary: Update Language by ID
+      description: An API to update the language details for requested ID.
+      parameters:
+        - $ref: '#/components/parameters/LangIdParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/updateLanguagePayload'
+      responses:
+        '200':
+          description: SUCCESS
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/getLangByIdResponse'
+        '400':
+          description: BAD_REQUEST
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/badRequestResponse'
+        '401':
+          description: UNAUTHORIZED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/unauthorizedResponse'
+        '403':
+          description: FORBIDDEN
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/forbiddenResponse'
+        '404':
+          description: NOT_FOUND
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/notFound'
+        '409':
+          description: CONFLICT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/userAlreadyExist'
         '500':
           description: INTERNAL_SERVER_ERROR
           content:

--- a/src/routes/support-language-routes/index.js
+++ b/src/routes/support-language-routes/index.js
@@ -2,8 +2,10 @@
 
 import registerSupportLanguage from './registerLanguage.route.js';
 import getLanguageInfo from './getLanguageInfo.route.js';
+import updateLanguageInfo from './updateLanguage.route.js';
 
 export default {
   registerSupportLanguage,
   getLanguageInfo,
+  updateLanguageInfo,
 };

--- a/src/routes/support-language-routes/updateLanguage.route.js
+++ b/src/routes/support-language-routes/updateLanguage.route.js
@@ -1,0 +1,58 @@
+'use strict';
+
+import { logger, buildApiResponse } from 'common-node-lib';
+import controllers from '../../controllers/index.js';
+
+const log = logger('Route: get-problem-type');
+const problemTypeController = controllers.problemTypeController;
+const languageController = controllers.languageController;
+
+// API Function
+const updateLanguageInfo = async (req, res, next) => {
+  try {
+    log.info('Language info for requested id update operation initiated');
+    const langId = req.params.langId;
+    const userId = req.user.id;
+    const payload = req.body;
+
+    log.info('Call controller function to validate if language info for requested id exists');
+    const langDtl = await languageController.getLangById(langId);
+    if (!langDtl.isValid) {
+      throw langDtl;
+    }
+
+    if (payload.typeId && payload.typeId !== langDtl.data.typeId) {
+      log.info('Call controller function to validate if problem type for newly provided id exists');
+      const typeDtl = await problemTypeController.getTypeById(payload.typeId);
+      if (!typeDtl.isValid) {
+        throw typeDtl;
+      }
+
+      payload['langCode'] = langDtl.data.langCode;
+
+      log.info('Call controller function to verify if language with new id and code valid to create');
+      const languageExist = await languageController.verifyLanguageExist(payload);
+      if (!languageExist.isValid) {
+        throw languageExist;
+      }
+    }
+
+    log.info('Call controller function to update the language info for provided id');
+    const updatedLangDtl = await languageController.updateLanguageInfoById(langId, userId, langDtl.data, payload);
+    if (!updatedLangDtl.isValid) {
+      throw updatedLangDtl;
+    }
+
+    log.success('Language info has been updated successfully');
+    res.status(200).json(buildApiResponse(updatedLangDtl));
+  } catch (err) {
+    if (err.statusCode === '500') {
+      log.error(`Error occurred while processing the request in router. Error: ${JSON.stringify(err)}`);
+    } else {
+      log.error(`Failed to complete the request. Error: ${JSON.stringify(err)}`);
+    }
+    next(err);
+  }
+};
+
+export default updateLanguageInfo;


### PR DESCRIPTION
Added updateLanguageByID API
- Process start by validating if the support language details for provided id exists.
- If exists then validate if the typeId has been provided in the payload and it differs from what exists in db.
- If so then validate if the typeId and language code combination valid to create or not.
- If valid then move forward with updating the language details in db.