### PR TITLE
Added delete language by ID API to the service

### DIFF
--- a/src/controllers/support-language-controllers/deleteLanguageInfo.controller.js
+++ b/src/controllers/support-language-controllers/deleteLanguageInfo.controller.js
@@ -1,0 +1,40 @@
+'use strict';
+
+import { convertPrettyStringToId, logger } from 'common-node-lib';
+import { deleteLanguageInfo } from '../../db/index.js';
+import { getLangById } from './getLanguage.controller.js';
+
+const log = logger('Controller: delete-problem-type');
+
+const deleteLanguageById = async (langId, userId) => {
+  try {
+    log.info('Controller function to delete language for provided id process initiated');
+    langId = convertPrettyStringToId(langId);
+    userId = convertPrettyStringToId(userId);
+
+    log.info('Call db query to soft delete the requested language info from system');
+    await deleteLanguageInfo(langId, userId);
+    let deletedLanguageInfo = await getLangById(langId, true);
+    deletedLanguageInfo = deletedLanguageInfo.data;
+
+    log.success('Requested language details has been soft deleted successfully');
+    return {
+      status: 200,
+      message: 'Language info deleted successfully',
+      data: deletedLanguageInfo,
+      isValid: true,
+    };
+  } catch (err) {
+    log.error('Error while deleting language info for requested id in system');
+    return {
+      status: 500,
+      message: 'An error occurred while deleting language info',
+      data: [],
+      errors: err,
+      stack: err.stack,
+      isValid: false,
+    };
+  }
+};
+
+export { deleteLanguageById };

--- a/src/controllers/support-language-controllers/index.js
+++ b/src/controllers/support-language-controllers/index.js
@@ -3,6 +3,7 @@
 import { verifyLanguageExist, registerNewLanguageType } from './registerLanguage.controller.js';
 import { getLangById, getAllLanguageInfo } from './getLanguage.controller.js';
 import { updateLanguageInfoById } from './updateLanguage.controller.js';
+import { deleteLanguageById } from './deleteLanguageInfo.controller.js';
 
 export default {
   verifyLanguageExist,
@@ -10,4 +11,5 @@ export default {
   getLangById,
   getAllLanguageInfo,
   updateLanguageInfoById,
+  deleteLanguageById,
 };

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -18,6 +18,7 @@ import {
   getLangInfoById,
   getAllLanguages,
   updateLanguageInfo,
+  deleteLanguageInfo,
 } from './problem.db.js';
 
 export {
@@ -38,4 +39,5 @@ export {
   getLangInfoById,
   getAllLanguages,
   updateLanguageInfo,
+  deleteLanguageInfo,
 };

--- a/src/db/problem.db.js
+++ b/src/db/problem.db.js
@@ -131,6 +131,13 @@ const updateLanguageInfo = async (langId, userId, payload) => {
   return exec(query, params);
 };
 
+const deleteLanguageInfo = async (langId, userId) => {
+  const query = `UPDATE SUPPORT_LANGUAGE SET IS_DELETED = true, MODIFIED_BY = ? WHERE ID = ?;`;
+  const params = [userId, langId];
+
+  return exec(query, params);
+};
+
 export {
   isProblemExistAvailable,
   registerNewType,
@@ -149,4 +156,5 @@ export {
   getLangInfoById,
   getAllLanguages,
   updateLanguageInfo,
+  deleteLanguageInfo,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ class ProblemService extends Service {
     this.app.get(`${PROBLEMS_API}/language`, routes.language.getLanguageInfo);
     this.app.get(`${PROBLEMS_API}/language/:langId`, routes.language.getLanguageInfo);
     this.app.put(`${PROBLEMS_API}/language/:langId`, routes.language.updateLanguageInfo);
+    this.app.delete(`${PROBLEMS_API}/language/:langId`, routes.language.deleteLanguage);
 
     // Problem Routes
     // this.app.post(`${PROBLEMS_API}/problem`, );

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1330,3 +1330,47 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/internalServerErrorResponse'
+
+    delete:
+      operationId: deleteLanguageById
+      summary: Delete Language by ID
+      description: An API to delete the language details for requested ID.
+      parameters:
+        - $ref: '#/components/parameters/LangIdParam'
+      responses:
+        '200':
+          description: SUCCESS
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/getLangByIdResponse'
+        '400':
+          description: BAD_REQUEST
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/badRequestResponse'
+        '401':
+          description: UNAUTHORIZED
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/unauthorizedResponse'
+        '403':
+          description: FORBIDDEN
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/forbiddenResponse'
+        '404':
+          description: NOT_FOUND
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/notFound'
+        '500':
+          description: INTERNAL_SERVER_ERROR
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/internalServerErrorResponse'

--- a/src/routes/support-language-routes/deleteLanguageInfo.route.js
+++ b/src/routes/support-language-routes/deleteLanguageInfo.route.js
@@ -1,0 +1,39 @@
+'use strict';
+
+import { logger, buildApiResponse } from 'common-node-lib';
+import controllers from '../../controllers/index.js';
+
+const log = logger('Route: delete-language');
+const languageController = controllers.languageController;
+
+// API Function
+const deleteLanguage = async (req, res, next) => {
+  try {
+    log.info('Language info for requested id delete operation initiated');
+    const langId = req.params.langId;
+    const userId = req.user.id;
+
+    log.info('Call controller function to validate if language info for requested id exists');
+    const langDtl = await languageController.getLangById(langId);
+    if (!langDtl.isValid) {
+      throw langDtl;
+    }
+
+    log.info('Call controller function to delete the requested support language info');
+    const deletedLangDtl = await languageController.deleteLanguageById(langId, userId);
+    if (!deletedLangDtl.isValid) {
+      throw deletedLangDtl;
+    }
+
+    res.status(200).json(buildApiResponse(deletedLangDtl));
+  } catch (err) {
+    if (err.statusCode === '500') {
+      log.error(`Error occurred while processing the request in router. Error: ${JSON.stringify(err)}`);
+    } else {
+      log.error(`Failed to complete the request. Error: ${JSON.stringify(err)}`);
+    }
+    next(err);
+  }
+};
+
+export default deleteLanguage;

--- a/src/routes/support-language-routes/index.js
+++ b/src/routes/support-language-routes/index.js
@@ -3,9 +3,11 @@
 import registerSupportLanguage from './registerLanguage.route.js';
 import getLanguageInfo from './getLanguageInfo.route.js';
 import updateLanguageInfo from './updateLanguage.route.js';
+import deleteLanguage from './deleteLanguageInfo.route.js';
 
 export default {
   registerSupportLanguage,
   getLanguageInfo,
   updateLanguageInfo,
+  deleteLanguage,
 };


### PR DESCRIPTION
Added deleteLanguageByID API
- Process initiate by validating if the language detail for the provided id exists.
- If exists then proceed with soft deleting the requested language.
- No core field validation required.