### PR TITLE
Updated register, get all, and get tag by id APIs in service

### DIFF
--- a/ReadME.md
+++ b/ReadME.md
@@ -3,7 +3,7 @@
 ## 🧩 Introduction
 Welcome to the GitHub repository for **Problems SVC** – This service is responsible for managing DSA and real-world API problems. It provides functionality to create, retrieve, and manage coding challenges and API-based problem definitions, which are later solved by users via dedicated execution engines.
 
-## 📌 Project Status: Under Development
+## 📌 Project Status: Development Completed
 ### What's Happening Now:
 - The service has been created to support the creation, management, and serving of coding challenges for users across different domains.
 

--- a/src/controllers/tag-controllers/getTag.controller.js
+++ b/src/controllers/tag-controllers/getTag.controller.js
@@ -11,6 +11,8 @@ const formatTagDtl = (tagDtl) => {
     id: convertIdToPrettyString(tagDtl.id),
     tagCode: tagDtl.tag_cd,
     tagDesc: tagDtl.tag_desc,
+    category: tagDtl.category,
+    metadata: JSON.parse(tagDtl.metadata),
     core: tagDtl.core,
     createdDate: convertToNativeTimeZone(tagDtl.created_date),
     modifiedDate: convertToNativeTimeZone(tagDtl.modified_date),
@@ -59,11 +61,25 @@ const getTagById = async (tagId, deletedRecord = false) => {
   }
 };
 
-const getAllTagInfo = async () => {
+const getAllTagInfo = async (category = null) => {
   try {
     log.info('Controller function to fetch all the tag info from system initiated');
+    if (category) {
+      category = category.trim().toUpperCase();
+
+      if (category !== 'TOPIC' && category !== 'COMPANY') {
+        log.error('Incorrect category query value provided');
+        return {
+          status: 404,
+          message: 'Incorrect category provided',
+          errors: [],
+          isValid: false,
+        };
+      }
+    }
+
     log.info('Call db query to fetch all tags from db');
-    let tagDtl = await getTags();
+    let tagDtl = await getTags(category);
     if (tagDtl.rowCount === 0) {
       log.info('No tag info available to display');
       return {
@@ -80,6 +96,7 @@ const getAllTagInfo = async () => {
         id: convertIdToPrettyString(tag.id),
         tagCode: tag.tag_cd,
         tagDesc: tag.tag_desc,
+        category: tag.category,
       };
     });
 

--- a/src/controllers/tag-controllers/registerTag.controller.js
+++ b/src/controllers/tag-controllers/registerTag.controller.js
@@ -47,7 +47,8 @@ const registerNewTag = async (payload) => {
   try {
     log.info('Controller function to register new tags in system initiated');
     log.info('Call db query to register new tag in system');
-    const newTag = await registerNewTagInfo(payload.tagCode, payload.tagDesc);
+    payload.metadata = JSON.stringify(payload.metadata);
+    const newTag = await registerNewTagInfo(payload.tagCode, payload.tagDesc, payload.category, payload.metadata);
     const newTagId = newTag.rows[0].id;
 
     const newTagDtl = await getTagById(newTagId);

--- a/src/db/problem.db.js
+++ b/src/db/problem.db.js
@@ -47,26 +47,32 @@ const isTagExist = async (tagCd) => {
   return exec(query, params);
 };
 
-const registerNewTagInfo = async (tagCd, tagDesc) => {
-  const query = `INSERT INTO TAGS (TAG_CD, TAG_DESC)
-    VALUES (?, ?)
+const registerNewTagInfo = async (tagCd, tagDesc, category, metadata) => {
+  const query = `INSERT INTO TAGS (TAG_CD, TAG_DESC, CATEGORY, METADATA)
+    VALUES (?, ?, ?, ?)
     RETURNING ID;`;
-  const params = [tagCd, tagDesc];
+  const params = [tagCd, tagDesc, category, metadata];
 
   return exec(query, params);
 };
 
 const getTagInfoById = async (tagId, deletedRecord) => {
-  const query = `SELECT ID, TAG_CD, TAG_DESC, CORE, CREATED_DATE, MODIFIED_DATE FROM TAGS
+  const query = `SELECT ID, TAG_CD, TAG_DESC, CATEGORY, METADATA, CORE, CREATED_DATE, MODIFIED_DATE FROM TAGS
     WHERE IS_DELETED = ? AND ID = ?;`;
   const params = [deletedRecord, tagId];
 
   return exec(query, params);
 };
 
-const getTags = async () => {
-  const query = `SELECT ID, TAG_CD, TAG_DESC FROM TAGS WHERE IS_DELETED = false;`;
-  return exec(query);
+const getTags = async (category = null) => {
+  let query = `SELECT ID, TAG_CD, TAG_DESC, CATEGORY FROM TAGS WHERE IS_DELETED = false`;
+  const params = [];
+
+  if (category) {
+    query += ` AND CATEGORY = ?;`;
+    params.push(category);
+  }
+  return exec(query, params);
 };
 
 const updateTagInfo = async (payload, userId, tagId) => {

--- a/src/db/problemTrans.db.js
+++ b/src/db/problemTrans.db.js
@@ -104,7 +104,6 @@ const deleteSheetRecords = async (sheetId, userId) => {
 };
 
 const updateSheetRecords = async (updatePayloads) => {
-  console.log(updatePayloads);
   const storeMultipleTagsRecord = updatePayloads.insertTagPayload.map(() => '(?, ?)').join(', ');
   const deleteMultipleTagsRecord = updatePayloads.deleteTagPayload.map(() => '?').join(', ');
   const storeMultipleExamplesRecords = updatePayloads.insertExamplePayload.map(() => '(?, ?, ?, ?)').join(', ');

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -94,9 +94,19 @@ components:
           type: string
           description:  Tag Description
           minLength: 1
+        category:
+          type: string
+          description: Category
+          enum:
+            - TOPIC
+            - COMPANY
+        metadata:
+          type: object
       required:
         - tagCode
         - tagDesc
+        - category
+        - metadata
 
     updateTagPayload:
       type: object
@@ -417,9 +427,14 @@ components:
         tagDesc:
           type: string
           example: Tag Description
+        category:
+          type: string
+          example: Tag Category
+        metadata:
+          type: object
         core:
           type: boolean
-          example: Core
+          example: false
         createdDate:
           type: string
         modifiedDate:
@@ -428,6 +443,7 @@ components:
         - id
         - tagCode
         - tagDesc
+        - category
 
     getLanguageResponseData:
       title: Schema for retrieving Language Details
@@ -1490,6 +1506,13 @@ paths:
       operationId: getAllTags
       summary: Get all Tags
       description: An API to retrieve all tags from the system.
+      parameters:
+        - in: query
+          name: category
+          schema:
+            type: string
+          required: false
+          description: Filter tags by category
       responses:
         '200':
           description: SUCCESS
@@ -1521,6 +1544,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/forbiddenResponse'
+        '404':
+          description: NOT_FOUND
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/notFound'
         '500':
           description: INTERNAL_SERVER_ERROR
           content:

--- a/src/routes/tag-routes/getTagInfo.route.js
+++ b/src/routes/tag-routes/getTagInfo.route.js
@@ -11,6 +11,7 @@ const getTagInfo = async (req, res, next) => {
   try {
     log.info('Get tag info request process initiated');
     const tagId = req.params.tagId;
+    const category = req.query.category;
     let tagDtl = {};
 
     if (tagId) {
@@ -18,7 +19,7 @@ const getTagInfo = async (req, res, next) => {
       tagDtl = await tagController.getTagById(tagId);
     } else {
       log.info('Call controller function to fetch all the tags available in system');
-      tagDtl = await tagController.getAllTagInfo();
+      tagDtl = await tagController.getAllTagInfo(category);
     }
     if (!tagDtl.isValid) {
       throw tagDtl;


### PR DESCRIPTION
- Updated registerTag API to accept the category and metadata field values for tags and store in DB.
- Updated getAllTags API to include the category field in the response payload.
- Added query functionality for the getAllTags API to enable querying based on the tag category.
- Updated getTagByID API to include the category and metadata fields in the response payload.